### PR TITLE
ジェネリック型を使いながらポリモーフィズムを理解する

### DIFF
--- a/src/generics/advanced.ts
+++ b/src/generics/advanced.ts
@@ -1,0 +1,32 @@
+export default function genericAdvancedSample() {
+  // map関数のシグネチャ
+  type Map<T, U> = (array: T[], fn: (item: T) => U) => U[]
+
+  const mapStringsToNumbers: Map<string, number> = (array, fn) => {
+    const result = []
+    for (let i = 0; i < array.length; i++) {
+      const item = array[i]
+      result[i] = fn(item)
+    }
+    return result
+  }
+
+  const numbers = mapStringsToNumbers(['123', '456', '789'], (item) => {
+    return Number(item)
+  })
+  console.log('Gererics advances sample 1:', numbers)
+
+  const mapNumbersToStrings: Map<number, string> = (array, fn) => {
+    const result = []
+    for (let i = 0; i < array.length; i++) {
+      const item = array[i]
+      result[i] = fn(item)
+    }
+    return result
+  }
+
+  const strings = mapNumbersToStrings(numbers, (item) => {
+    return String(item)
+  })
+  console.log('Gererics advances sample 2:', strings)
+}

--- a/src/generics/basic.ts
+++ b/src/generics/basic.ts
@@ -1,0 +1,85 @@
+export default function genericsBasicSample() {
+  /**
+   * ジェネリック型を使わない場合
+   */
+  const stringReduce = (array: string[], initialValue: string): string => {
+    let result = initialValue
+    for (let i = 0; i < array.length; i++) {
+      result += array[i]
+    }
+    return result
+  }
+  console.log('Gererics basic sample 1:', stringReduce(['hoge', 'piyo', 'fuga'], 'start'))
+  const numberReduce = (array: number[], initialValue: number): number => {
+    let result = initialValue
+    for (let i = 0; i < array.length; i++) {
+      result += array[i]
+    }
+    return result
+  }
+  console.log('Gererics basic sample 2:', numberReduce([100, 200, 300], 1000))
+
+  // ジェネリック型を使わずに型定義をする
+  type Reduce = {
+    (array: string[], initialValue: string): string
+    (array: number[], initialValue: number): number
+    // booleanのときは？など都度追加するのが大変になる・・・のでジェネリック型で型定義をするのがよい
+  }
+
+  /**
+   * ジェネリック型を使う場合
+   */
+  type GenericReduce<T> = {
+    (array: T[], initialValue: T): T
+  }
+
+  // ジェネリック型の T に stringを渡す
+  const genericStringReduce: GenericReduce<string> = (array, initialValue) => {
+    let result = initialValue
+    for (let i = 0; i < array.length; i++) {
+      result += `${array[i]} `
+    }
+    return result
+  }
+  console.log('Gererics basic sample 3:', genericStringReduce(['MAKE', 'TYPESCRIPT'], ''))
+
+  // ジェネリック型の T に numberを渡す
+  const genericNumberReduce: GenericReduce<number> = (array, initialValue) => {
+    let result = initialValue
+    for (let i = 0; i < array.length; i++) {
+      result += array[i]
+    }
+    return result
+  }
+  console.log('Gererics basic sample 4:', genericNumberReduce([1, 2, 3], 100))
+
+  /**
+   * いろいろなジェネリック型の定義方法
+   */
+
+  // 完全な呼び出しシグネチャ（個々のシグネチャにジェネリック型を割り当てる）
+  type GenericReduce2 = {
+    <T>(array: T[], initialValue: T): T
+    <U>(array: U[], initialValue: U): U
+  }
+  // ジェネリック型の T に numberを渡す
+  const genericNumberReduce2: GenericReduce2 = (array: number[], initialValue: number) => {
+    let result = initialValue
+    for (let i = 0; i < array.length; i++) {
+      result += array[i]
+    }
+    return result
+  }
+  console.log('Gererics basic sample 5:', genericNumberReduce2([1, 2, 3], 100))
+
+  // 呼び出しシグネチャの省略記法
+  type GenericReduce3<T> = (array: T[], initialValue: T) => T
+  const genericNumberReduce3: GenericReduce3<number> = (array, initialValue) => {
+    let result = initialValue
+    for (let i = 0; i < array.length; i++) {
+      result += array[i]
+    }
+    return result
+  }
+  console.log('Gererics basic sample 6:', genericNumberReduce3([1, 2, 3], 100))
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,15 +50,25 @@ import objectSample from './object/object'
 
 // objectSample()
 
+// 06. 型エイリアスでオブジェクトの型定義
 import typeAliasSample from './object/alias'
 
 // typeAliasSample()
 
-// 06. 配列・タプルの型定義
+// 07. 配列・タプルの型定義
 import arraySample from './array/array'
 
-arraySample()
+// arraySample()
 
 import tupleSample from './array/tuple'
 
-tupleSample()
+// tupleSample()
+
+// 08. ジェネリック型を使いながらポリモーフィズムを理解する
+import genericsBasicSample from './generics/basic'
+
+genericsBasicSample()
+
+import genericAdvancedSample from './generics/advanced'
+
+genericAdvancedSample()


### PR DESCRIPTION
下記動画を基に学習を進めました。

【日本一わかりやすいTypeScript入門】ジェネリック型を使いながらポリモーフィズムを理解する. 
https://www.youtube.com/watch?v=5JYZzB7MMvo&list=PLX8Rsrpnn3IW0REXnTWQp79mxCvHkIrad&index=8

## 型を抽象化するジェネリック型
- 型の種類は異なるが、同じデータの構造をしている場合などにジェネリック型パラメータで共通化する
```
const stringReduce = (array: string[], initialValue: string): string => {}
const numberReduce = (array: number[], initialValue: number): number => {}
```

### ジェネリック型パラメータ
- 型をパラメータ化（後から実パラメータを渡す）
- T,U,V,Wなどのパラメータがよく用いられる
```
type Reduce<T> = {
    (array: T[], initialValue: T): T
}

// Tにstring型を渡す
const reduce: Reduce<string> = (array, initialValue) => {}
```

### ジェネリックの宣言方法
「呼び出しシグネチャの記法」と「ジェネリック型の割り当て範囲」によって異なる
```
// 完全な呼び出しシグネチャ（シグネチャ全体にジェネリック型を割り当てる）

// 完全な呼び出しシグネチャ（個々のシグネチャにジェネリック型を割り当てる）
type GenericRedice2 = {
    <T>(array: T[], initialValue: T): T
    <U>(array: U[], initialValue: U): U
}

// 呼び出しシグネチャの省略記法
type GenericReduce3<T> = (array: T[], initialValue: T): T
type GenericReduce4 = <T>(array: T[], initialValue: T): T
```
## ポリモーフィズム=呼び出し側の共通化
### ポリモーフィズム
- 多態性・多相性＝いろいろな形に変化できること。ジェネリック型を用いることで下記が実現でき、保守性が上がる。

1. 型を抽象化して共通化できる
1. 呼び出すときに具体的な型を渡す
