### PR TITLE
ハンズオンで理解するInterfaceとType Aliasの違い

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,3 +78,10 @@ import Game from './oop/shogi'
 
 const game = new Game()
 console.log(game)
+
+// 09. TypeScriptで学ぶオブジェクト指向開発
+import Comic from './interface/interface'
+
+const popularComic = new Comic(200, '鬼滅の刃', '2020')
+console.log(popularComic.getPublishYear())
+console.log(popularComic.getPage())

--- a/src/interface/interface.ts
+++ b/src/interface/interface.ts
@@ -1,0 +1,90 @@
+// interfaceで表現する場合
+interface Bread {
+  calories: number
+}
+
+interface Bread {
+  type: string
+}
+
+// 宣言のマージがされるので、 calories, typeの両方の宣言が必要
+const francePan: Bread = {
+  calories: 300,
+  type: 'hard',
+}
+
+// 型エイリアスで表現する場合
+type MaboDofu = {
+  calories: number
+  spicyLevel: number
+}
+
+type Rice = {
+  calories: number
+  gram: number
+}
+
+type MaboDon = MaboDofu & Rice // 交差型(union)
+
+const maboDon: MaboDon = {
+  calories: 500,
+  spicyLevel: 10,
+  gram: 350,
+}
+
+/**
+ * インターフェースの継承
+ */
+interface Book {
+  page: number
+  title: string
+}
+
+interface Magazine extends Book {
+  cycle: 'daily' | 'weekly' | 'monthly' | 'yearly' | 'season'
+}
+
+const jump: Magazine = {
+  page: 300,
+  title: '週刊少年ジャンプ',
+  cycle: 'weekly',
+}
+
+/**
+ * 型エイリアスをインターフェースに継承させることもできる
+ */
+type Booktype = {
+  page: number
+  title: string
+}
+
+interface Handbook extends Booktype {
+  theme: string
+}
+
+const cotrip: Handbook = {
+  page: 120,
+  title: 'ことりっぷ',
+  theme: '旅行',
+}
+
+/**
+ * implementsを使ってclassに型を定義する
+ */
+export default class Comic implements Book {
+  page: number
+  title: string
+
+  constructor(pg: number, ttl: string, private publishYear: string) {
+    this.page = pg
+    this.title = ttl
+  }
+
+  getPublishYear() {
+    return `${this.title}が発売されたのは${this.publishYear}年です`
+  }
+
+  getPage() {
+    return `${this.title}は${this.page}ページで構成されています`
+  }
+}


### PR DESCRIPTION
下記動画を基に学習を進めました。

【日本一わかりやすいTypeScript入門】ハンズオンで理解するInterfaceとType Aliasの違い  
https://www.youtube.com/watch?v=J2vox52T4W8&list=PLX8Rsrpnn3IW0REXnTWQp79mxCvHkIrad&index=10

## Type AliasとInterfaceの誤読
- TypeAlias(型エイリアス)とInterfaceの機能は2021年時点のバージョンでは大差はない
- 2016年時点では、すべてのソフトウェアは拡張的であるべきなのでInterfaceであるべき…という言説があったがケースバイケースで使うのが良さそう
- ライブラリ: 不特定多数が利用するので拡張性を持つべき
- アプリケーション: すべての型が拡張性を持つとバグを生む危険性がある

## Interfaceの基本用法と宣言のマージ
- interface 宣言子で定義
- Type Aliasと違って「=」は不要
```
interface Bread {
    calories: number
}
```

- 同名のinterfaceを宣言すると型が追加（マージ）される
- 宣言のマージ: 同じ名前を共有する複数の宣言を自動的に結合する
```
interface: Bread {
    type: string
}

const fransPan: Bread = {
    calories: 350,
    type: 'hard'
}
```

## Interfaceの拡張
- extends(継承)を使うことで継承したサブインターフェースを作れる
- Type Aliasをextendsすることもできる
```
interface Book {
    page: number
    title: string
}

interface Magazine extends Book {
    cycle: 'daily' | 'weekly' | 'monthly' | 'yearly' |
}

const jump: Magazine = {
    cycle: 'weekly',
    page: 300,
    title: '少年ジャンプ'
}
```

## implementsを使ってclassに型を定義できる
```
interface Book {
    page: number
    title: string
}

class Comic implements Book {
    page: number;
    title: string;

    constructor(page: number, title: string) {
        ///
    }
}
```

## Type Alias とInterfaceの違いまとめ

||Type Alias|Interface|
|---|---|---|
|用途|複数の場所で再利用する型に名前をつけるため|オブジェクト・クラス・関数の構造を定義するため|
|拡張性|同名のtypeを宣言するとエラー|同名のinterfaceを宣言するとマージできる|
|継承|継承はできない。交差型で新しい型エイリアスを作る|extendsによる継承ができる。継承に型エイリアスを用いることもできる|
|使用できる型|オブジェクトや関数以外のプリミティブ・配列・タプルも宣言可能|オブジェクトと関数の型のみ宣言できる|
|考慮事項|拡張しにくい不便さがある＝堅牢ということでもある|拡張性が高い＝「どこで継承生まれてるの？」がコードによっては追いかけにくくバグを生む可能性もあるということ|
|いつ使う？|アプリ開発ではType Alias|ライブラリ開発ではInterface|

